### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -2,7 +2,7 @@ h1. zlist
 
 Parses your CSS files for z-index declarations and builds an ordered list of them. Useful for debugging/editing stacking orders.
 
-!https://pypip.in/download/zlist/badge.svg?period=month! !https://pypip.in/version/zlist/badge.svg! !https://pypip.in/py_versions/zlist/badge.svg! !https://pypip.in/status/zlist/badge.svg!
+!https://img.shields.io/pypi/dm/zlist.svg! !https://img.shields.io/pypi/v/zlist.svg! !https://img.shields.io/pypi/pyversions/zlist.svg! !https://img.shields.io/pypi/status/zlist.svg!
 
 h2. Installation
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20zlist))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `zlist`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.